### PR TITLE
ci(docs): Action to generate docs

### DIFF
--- a/.github/workflows/panvimdoc.yml
+++ b/.github/workflows/panvimdoc.yml
@@ -1,0 +1,25 @@
+name: panvimdoc
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - README.md
+      - docs/*
+      - .github/workflows/panvimdoc.yml
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: kdheepak/panvimdoc@main
+        with:
+          vimdoc: ${{ github.event.repository.name }}
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "chore: generate docs"
+          branch: ${{ github.head_ref }}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Plugin for displaying the inlay hints for the current line in the echo area.
   - [x] Typechecking
   - [x] Formatting
   - [ ] Testing
-  - [ ] Docgen
+  - [x] Docgen
 - [ ] Initial version of plugin (just pulled from my config, no parameters).
 - [ ] Configure auto-enable
 - [ ] Configure display callback


### PR DESCRIPTION
Runs on pushes to `main` that touch the README, the rule or the docs directory.