### PR TITLE
ci(docs): Set title and nvim version

### DIFF
--- a/.github/workflows/panvimdoc.yml
+++ b/.github/workflows/panvimdoc.yml
@@ -20,7 +20,8 @@ jobs:
           token: ${{ secrets.DOCS_PAT }}
       - uses: kdheepak/panvimdoc@main
         with:
-          vimdoc: ${{ github.event.repository.name }}
+          vimdoc: "lsp-echohint"
+          version: "NVIM v0.10.0"
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "chore: generate docs"


### PR DESCRIPTION
Configure docs title and the supported nvim version -- inlay hints landed in 0.10.0.