### PR TITLE
fix: Off-by-one on treesitter line

### DIFF
--- a/lua/lsp-echohint/init.lua
+++ b/lua/lsp-echohint/init.lua
@@ -44,7 +44,7 @@ local function display(line, hints)
     if hint.kind == 1 then
       local node = vim.treesitter.get_node {
         pos = {
-          line,
+          line - 1,
           hint.character - 1,
         },
       }


### PR DESCRIPTION
Treesitter was fetching the node from the line below the one it was supposed to. This happened because previously the lines for treesitter were coming from the inlay hints response, and now they are coming from vim's cursor position, which must be off-by-one.