### PR TITLE
fix: limit size of value hints

### DIFF
--- a/lua/lsp-echohint/init.lua
+++ b/lua/lsp-echohint/init.lua
@@ -14,8 +14,7 @@ local function value_hint(line, character)
 
   print(vim.inspect(#text))
   for child, child_text in node:iter_children() do
-    print(vim.inspect(child))
-    print(vim.inspect(child_text))
+    print("Node", child:sexpr())
   end
 
   return text

--- a/lua/lsp-echohint/init.lua
+++ b/lua/lsp-echohint/init.lua
@@ -11,10 +11,10 @@ local function value_hint(line, character)
   if not node then return end
 
   local text = vim.treesitter.get_node_text(node, 0)
-  if #text < 20 or text:match "\n" then
-    return text
-  else
+  if #text > 20 or text:match "\n" then
     return text:gsub("\n *", " "):sub(1, 17) .. "..."
+  else
+    return text
   end
 end
 

--- a/lua/lsp-echohint/init.lua
+++ b/lua/lsp-echohint/init.lua
@@ -1,23 +1,21 @@
 local M = {}
 
+---Try and find a treesitter node near `line` and `character` and get its
+---contents as a string to use as the value part of a `value: type` hint.
+---
+---If the value is too long or contains newlines, it is truncated by replacing
+---newlines with spaces, and limiting the overall length to 20 characters
+---(including an ellipsis).
 local function value_hint(line, character)
-  local node = vim.treesitter.get_node {
-    pos = {
-      line - 1,
-      character - 1,
-    },
-  }
-
+  local node = vim.treesitter.get_node { pos = { line - 1, character - 1 } }
   if not node then return end
 
   local text = vim.treesitter.get_node_text(node, 0)
-
-  print(vim.inspect(#text))
-  for child, child_text in node:iter_children() do
-    print("Node", child:sexpr())
+  if #text < 20 or text:match "\n" then
+    return text
+  else
+    return text:gsub("\n *", " "):sub(1, 17) .. "..."
   end
-
-  return text
 end
 
 ---@alias EchoText [string, string]

--- a/lua/lsp-echohint/init.lua
+++ b/lua/lsp-echohint/init.lua
@@ -1,5 +1,26 @@
 local M = {}
 
+local function value_hint(line, character)
+  local node = vim.treesitter.get_node {
+    pos = {
+      line - 1,
+      character - 1,
+    },
+  }
+
+  if not node then return end
+
+  local text = vim.treesitter.get_node_text(node, 0)
+  if #text < 20 then return text end
+
+  for child, child_text in node:iter_children() do
+    print(vim.inspect(child))
+    print(vim.inspect(child_text))
+  end
+
+  return text
+end
+
 ---@alias EchoText [string, string]
 
 ---@class EchoHint
@@ -49,16 +70,10 @@ local function display(line, hints)
     -- If this is a type hint, try to find the expression that this type
     -- corresponds to, using treesitter.
     if hint.kind == 1 then
-      local node = vim.treesitter.get_node {
-        pos = {
-          line - 1,
-          hint.character - 1,
-        },
-      }
+      local value = value_hint(line, hint.character)
 
-      if node then
-        local text = vim.treesitter.get_node_text(node, 0)
-        table.insert(tokens, { text, "Identifier" })
+      if value then
+        table.insert(tokens, { value, "Identifier" })
         table.insert(tokens, { ": ", "Delimiter" })
       end
 

--- a/lua/lsp-echohint/init.lua
+++ b/lua/lsp-echohint/init.lua
@@ -11,8 +11,8 @@ local function value_hint(line, character)
   if not node then return end
 
   local text = vim.treesitter.get_node_text(node, 0)
-  if #text < 20 then return text end
 
+  print(vim.inspect(#text))
   for child, child_text in node:iter_children() do
     print(vim.inspect(child))
     print(vim.inspect(child_text))


### PR DESCRIPTION
When pulling values associated with types, if that value is too big,
contract it so that the echo area doesn't take over the screen.